### PR TITLE
Support master branch in sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ If there isn't, you can add it by doing:
 git remote add origin <the URL to your forked repo>
 ```
 
-3. The main branch is named `main`.
-`git sync` will stash any changes you have on your current branch, checkout `main`, sync it with upstream and with your fork, and then switch back to your current branch and pop off of the stash to restore your working tree and index.
+3. Both your git client and the git installed on your remotes support `git ls-remote --symref` (most do, just a very old version might not).
+
+`git sync` will stash any changes you have on your current branch, checkout the local branch which is `HEAD` (aka the main branch) on the upstream remote, 
+sync it with upstream and with your fork, and then switch back to your current branch and pop off of the stash to restore your working tree and index.
 
 ## Git Clone Fork
 Note: this command currently only works with github repositories!

--- a/git-sync
+++ b/git-sync
@@ -15,11 +15,12 @@
 # limitations under the License.
 
 echo "Synching upstream remote with origin"
+BRANCH="$(git ls-remote --symref origin HEAD | grep ref: | sed 's/^ref: refs\/heads\/\(.*\)[[:space:]]HEAD$/\1/')"
 GIT_STASH_MESSAGE="${RANDOM}"
-git stash push -m "{GIT_STASH_MESSAGE}"
-git checkout main
-git pull upstream main --ff-only
-git push origin main
+git stash push -m "${GIT_STASH_MESSAGE}"
+git checkout "${BRANCH}"
+git pull upstream "${BRANCH}" --ff-only
+git push origin "${BRANCH}" 
 git switch -
 git stash list | grep "${GIT_STASH_MESSAGE}" && git stash pop 0 --index
 exit 0


### PR DESCRIPTION
Fixes #11 

This PR finds the branch name referred to by `HEAD` on the `origin` repository, and then uses that branch name for all the git sync commands.