### PR TITLE
Check if jq installed in install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # git-utils
 A collection of useful git tools. Currently the only tool here is a git command to sync an upstream repository with your local copy and your fork.
 
-> :warning: **If you are not on Linux**: these scripts have only been tested on Linux so far. Please open an issue if you find any compatibility problems.
+> :warning: **If you are not on Linux/MacOS**: these scripts have only been tested on Linux and MacOS so far. Please open an issue if you find any compatibility problems.
 
 ## Git Sync
 ### Usage

--- a/install.sh
+++ b/install.sh
@@ -35,8 +35,6 @@ while getopts "n:" flag; do
     esac
 done
 
-echo "$NAME"
-
 if [[ ":$PATH:" == *":$HOME/bin:"* ]]; then
   echo "Your path is correctly set"
 else

--- a/install.sh
+++ b/install.sh
@@ -18,13 +18,24 @@ function install_git_util_command() {
     ln -s "$(pwd)/$1" "${HOME}/bin/$1"
 }
 
+function check_git_util_dep_installed() {
+    if ! command -v "$1" &> /dev/null
+    then
+        echo "$1 is a dependency for $2. Please install it before installing $2"
+        return 1
+    fi
+    return 0
+}
+
 while getopts "n:" flag; do
-    case '${flag}' in 
-        n) NAME=${OPTARG} ;;
+    case "${flag}" in 
+        n) NAME="${OPTARG}" ;;
         ?) printf "Usage: %s: [-n name_of_command_to_install]\n" $0
             exit 2;;
     esac
 done
+
+echo "$NAME"
 
 if [[ ":$PATH:" == *":$HOME/bin:"* ]]; then
   echo "Your path is correctly set"
@@ -36,9 +47,9 @@ fi
 mkdir -p "${HOME}/bin"
 
 if [[ -z "$NAME" || "$NAME" = "git-sync" ]]; then
-    install_git_util_command "git-sync"
+    install_git_util_command "git-sync" && echo "installed git_sync"
 fi
 
-if [[ -z "$NAME" || "$NAME" = "git-clonefork" ]]; then
-   install_git_util_command "git-clonefork" 
+if [[ (-z "$NAME" || "$NAME" = "git-clonefork") ]]; then
+    check_git_util_dep_installed "jq" "git-clonefork" && install_git_util_command "git-clonefork" && echo "intalled git_clonefork"
 fi


### PR DESCRIPTION
Fixes #10 

With this change, I am comfortable saying that this supports MacOS as the only dependency needed on mac is `jq` which we are now testing for in the installation.