### PR TITLE
Added checkout of main branch if not exists

### DIFF
--- a/git-sync
+++ b/git-sync
@@ -18,7 +18,12 @@ echo "Synching upstream remote with origin"
 BRANCH="$(git ls-remote --symref origin HEAD | grep ref: | sed 's/^ref: refs\/heads\/\(.*\)[[:space:]]HEAD$/\1/')"
 GIT_STASH_MESSAGE="${RANDOM}"
 git stash push -m "${GIT_STASH_MESSAGE}"
-git checkout "${BRANCH}"
+if [[ -z "$(git branch -l ${BRANCH})" ]] 
+then
+    git checkout --track "origin/${BRANCH}"
+else
+    git checkout "${BRANCH}"
+fi
 git pull upstream "${BRANCH}" --ff-only
 git push origin "${BRANCH}" 
 git switch -


### PR DESCRIPTION
Fixes #15 

Currently if there is no copy of the branch referred to by `HEAD` locally, the git sync command will work but will throw a whole bunch of warnings at you (it won't know whether to check out upstream/main or origin/main for example). So, we should check if there is a copy locally, and check it out if there is not