### PR TITLE
Added explanation of how to add ~/bin to path to install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -39,6 +39,9 @@ if [[ ":$PATH:" == *":$HOME/bin:"* ]]; then
   echo "Your path is correctly set"
 else
   echo "Your path is missing ~/bin, you might want to add it."
+  echo "If you use bash, add 'export PATH=\"\${PATH}:\${HOME}/bin\"' to your .bashrc file"
+  echo "If you use zsh, add 'export PATH=\"\${PATH}:\${HOME}/bin\"' to your .zshrc file"
+  echo "If you use fish, add 'fish_add_path -m ~/bin' to your config.fish file"
   exit 1
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -39,9 +39,9 @@ if [[ ":$PATH:" == *":$HOME/bin:"* ]]; then
   echo "Your path is correctly set"
 else
   echo "Your path is missing ~/bin, you might want to add it."
-  echo "If you use bash, add 'export PATH=\"\${PATH}:\${HOME}/bin\"' to your .bashrc file"
-  echo "If you use zsh, add 'export PATH=\"\${PATH}:\${HOME}/bin\"' to your .zshrc file"
-  echo "If you use fish, add 'fish_add_path -m ~/bin' to your config.fish file"
+  echo "If you use bash, add 'export PATH=\"\${PATH}:\${HOME}/bin\"' to your .bashrc file, and then run \"source .bashrc\""
+  echo "If you use zsh, add 'export PATH=\"\${PATH}:\${HOME}/bin\"' to your .zshrc file, and then run \"source .zshrc\""
+  echo "If you use fish, add 'fish_add_path -m ~/bin' to your config.fish file, and then run \"source config.fish\""
   exit 1
 fi
 


### PR DESCRIPTION
Fixes #16 

With this new code, running the install script without `~/bin` in my path produces the following message:

```
./install.sh      
Your path is missing ~/bin, you might want to add it.
If you use bash, add 'export PATH="${PATH}:${HOME}/bin"' to your .bashrc file
If you use zsh, add 'export PATH="${PATH}:${HOME}/bin"' to your .zshrc file
If you use fish, add 'fish_add_path -m ~/bin' to your config.fish file
```