### PR TITLE
Add the full path to the error prompt message

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -39,9 +39,9 @@ if [[ ":$PATH:" == *":$HOME/bin:"* ]]; then
   echo "Your path is correctly set"
 else
   echo "Your path is missing ~/bin, you might want to add it."
-  echo "If you use bash, add 'export PATH=\"\${PATH}:\${HOME}/bin\"' to your .bashrc file, and then run \"source .bashrc\""
-  echo "If you use zsh, add 'export PATH=\"\${PATH}:\${HOME}/bin\"' to your .zshrc file, and then run \"source .zshrc\""
-  echo "If you use fish, add 'fish_add_path -m ~/bin' to your config.fish file, and then run \"source config.fish\""
+  echo "If you use bash, add 'export PATH=\"\${PATH}:\${HOME}/bin\"' to your ~/.bashrc file, and then run \"source ~/.bashrc\""
+  echo "If you use zsh, add 'export PATH=\"\${PATH}:\${HOME}/bin\"' to your ~/.zshrc file, and then run \"source ~/.zshrc\""
+  echo "If you use fish, add 'fish_add_path -m ~/bin' to your config.fish file, and then run \"source ~/.config/fish/config.fish\""
   exit 1
 fi
 


### PR DESCRIPTION
Some users complained that after they copied the command `source .zshrc` to their terminal, that doesn't work. So to make it more intuitive for our users, suggest the changes in this PR.