### PR TITLE
Added alias for git commit -s -m

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -54,3 +54,7 @@ fi
 if [[ (-z "$NAME" || "$NAME" = "git-clonefork") ]]; then
     check_git_util_dep_installed "jq" "git-clonefork" && install_git_util_command "git-clonefork" && echo "intalled git_clonefork"
 fi
+
+if [[ (-z "$NAME" || "$NAME" = "csm") ]]; then
+    git config --global alias.csm "commit -s -m"
+fi


### PR DESCRIPTION
I often find myself writing `git commit -s -m "commit message"`.

This sets a simple alias for this command, simplifying the code to `git csm "commit message"`